### PR TITLE
Persistent Project Id

### DIFF
--- a/src/main/webapp/app/services/user/project-manager.service.js
+++ b/src/main/webapp/app/services/user/project-manager.service.js
@@ -1,0 +1,32 @@
+/**
+ * Created by Hung.
+ */
+(function() {
+    'use strict';
+    angular
+        .module('thefirstorderApp')
+        .factory('ProjectManager', ProjectManager);
+
+    ProjectManager.$inject = ['$http'];
+
+    function ProjectManager ($http) {
+        var resourceUrl =  'api/account/';
+        var service = {
+            get: get,
+            update: update
+        };
+        return service;
+
+        function get() {
+            return $http.get('api/account/currentproject');
+        }
+
+        function update(id) {
+            return $http.put(
+                'api/account/update_currentproject',
+                {},
+                { params: {projectId: id} }
+            );
+        }
+    }
+})();

--- a/src/test/java/nl/tudelft/thefirstorder/web/rest/ProjectManagerResourceIntTest.java
+++ b/src/test/java/nl/tudelft/thefirstorder/web/rest/ProjectManagerResourceIntTest.java
@@ -79,9 +79,7 @@ public class ProjectManagerResourceIntTest {
         doNothing().when(mockMailService).sendActivationEmail((User) anyObject(), anyString());
 
         ProjectManagerResource projectManagerResource = new ProjectManagerResource();
-//        ReflectionTestUtils.setField(projectManagerResource, "userRepository", userRepository);
         ReflectionTestUtils.setField(projectManagerResource, "userService", mockUserService);
-//        ReflectionTestUtils.setField(projectManagerResource, "mailService", mockMailService);
 
         this.restUserMockMvc = MockMvcBuilders.standaloneSetup(projectManagerResource).build();
     }
@@ -101,29 +99,10 @@ public class ProjectManagerResourceIntTest {
         user.setAuthorities(authorities);
         user.setCurrentProjectId(321L);
         when(mockUserService.getUserWithAuthorities()).thenReturn(user);
-//        doAnswer(invocation -> {
-////            Object[] args = invocation.getArguments();
-//            user.setCurrentProjectId(123L);
-//            return null;
-//        }).when(mockUserService).updateUserProjectId(anyLong());
 
-
-//        restUserMockMvc.perform(get("/api/account/currentproject")
-//                .accept(MediaType.APPLICATION_JSON))
-//                .andExpect(status().isNotFound());
-
-//        doCallRealMethod().when(mockUserService).updateUserProjectId(anyLong());
-        restUserMockMvc.perform(put("/api/account/update_currentproject?projectId=123"))
-//                .param("projectId", String.valueOf(projectId)))
+        restUserMockMvc.perform(put("/api/account/update_currentproject")
+                .param("projectId", String.valueOf(projectId)))
                 .andExpect(status().isOk());
-//                .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
-
-//        MvcResult result = restUserMockMvc.perform(get("/api/account/currentproject")
-//                .accept(MediaType.APPLICATION_JSON))
-//                .andExpect(status().isOk())
-//                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-//                .andReturn();
-//        assertThat(result.getResponse().getContentAsString()).isEqualTo(String.valueOf(projectId));
     }
 
     @Test


### PR DESCRIPTION
This feature adds the `currentProjectId` attribute to the User entity. That way, a user has the same projectId across all pages.   
A Liquibase changelog has been created to correctly add the column to the User table. An URI mapping has been created to fetch the currentProjectId(`api/account/currentproject`). To change the currentProjectId to `123`, call `api/account/update_currentproject?projectId=123`. 
Also added tests for the new resource class.   

I will add an AngularJS service to fetch this attribute in the frontend. 