### PR TITLE
Fix missing relationships between entities

### DIFF
--- a/.jhipster/Cue.json
+++ b/.jhipster/Cue.json
@@ -39,6 +39,12 @@
             "otherEntityName": "camera",
             "relationshipType": "many-to-one",
             "otherEntityField": "name"
+        },
+        {
+            "relationshipName": "project",
+            "otherEntityName": "project",
+            "relationshipType": "many-to-one",
+            "otherEntityField": "name"
         }
     ],
     "fields": [],

--- a/.jhipster/Project.json
+++ b/.jhipster/Project.json
@@ -27,6 +27,12 @@
             "otherEntityName": "camera",
             "relationshipType": "one-to-many",
             "otherEntityRelationshipName": "project"
+        },
+        {
+            "relationshipName": "cue",
+            "otherEntityName": "cue",
+            "relationshipType": "one-to-many",
+            "otherEntityRelationshipName": "project"
         }
     ],
     "fields": [

--- a/src/main/java/nl/tudelft/thefirstorder/domain/Cue.java
+++ b/src/main/java/nl/tudelft/thefirstorder/domain/Cue.java
@@ -48,6 +48,10 @@ public class Cue implements Serializable {
     @JoinColumn(unique = true)
     private TimePoint timePoint;
 
+    @ManyToOne
+    @JoinColumn
+    private Project project;
+
     /**
      * Get the id of the cue.
      * @return the id
@@ -120,6 +124,13 @@ public class Cue implements Serializable {
         this.timePoint = timePoint;
     }
 
+    public Project getProject() {
+        return project;
+    }
+
+    public void setProject(Project project) {
+        this.project = project;
+    }
 
     /**
      * Checks if two cues are the same.

--- a/src/main/java/nl/tudelft/thefirstorder/domain/Map.java
+++ b/src/main/java/nl/tudelft/thefirstorder/domain/Map.java
@@ -8,9 +8,14 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
+import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import java.io.Serializable;
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * A Map.
@@ -28,6 +33,14 @@ public class Map implements Serializable {
 
     @Column(name = "name")
     private String name;
+
+    @OneToMany
+    @JoinTable(name = "map_cameras",
+            joinColumns = @JoinColumn(name = "map_id"),
+            inverseJoinColumns = @JoinColumn(name = "camera_id")
+    )
+//    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+    private Set<Camera> cameras = new HashSet<>();
 
     /**
      * Get the id of the map.
@@ -59,6 +72,18 @@ public class Map implements Serializable {
      */
     public void setName(String name) {
         this.name = name;
+    }
+
+    public Set<Camera> getCameras() {
+        return cameras;
+    }
+
+    public void setCameras(Set<Camera> cameras) {
+        this.cameras = cameras;
+    }
+
+    public void addCamera(Camera camera) {
+        this.cameras.add(camera);
     }
 
     /**

--- a/src/main/java/nl/tudelft/thefirstorder/domain/Map.java
+++ b/src/main/java/nl/tudelft/thefirstorder/domain/Map.java
@@ -39,8 +39,16 @@ public class Map implements Serializable {
             joinColumns = @JoinColumn(name = "map_id"),
             inverseJoinColumns = @JoinColumn(name = "camera_id")
     )
-//    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private Set<Camera> cameras = new HashSet<>();
+
+    @OneToMany
+    @JoinTable(name = "map_players",
+            joinColumns = @JoinColumn(name = "map_id"),
+            inverseJoinColumns = @JoinColumn(name = "player_id")
+    )
+    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+    private Set<Player> players = new HashSet<>();
 
     /**
      * Get the id of the map.
@@ -82,8 +90,28 @@ public class Map implements Serializable {
         this.cameras = cameras;
     }
 
+    /**
+     * Adds a camera to the map.
+     * @param camera Camera
+     */
     public void addCamera(Camera camera) {
-        this.cameras.add(camera);
+        cameras.add(camera);
+    }
+
+    public Set<Player> getPlayers() {
+        return players;
+    }
+
+    public void setPlayers(Set<Player> players) {
+        this.players = players;
+    }
+
+    /**
+     * Adds a player to the map.
+     * @param player Player
+     */
+    public void addPlayer(Player player) {
+        players.add(player);
     }
 
     /**

--- a/src/main/java/nl/tudelft/thefirstorder/domain/Project.java
+++ b/src/main/java/nl/tudelft/thefirstorder/domain/Project.java
@@ -53,6 +53,11 @@ public class Project implements Serializable {
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private Set<Camera> cameras = new HashSet<>();
 
+    @OneToMany(mappedBy = "project")
+    @JsonIgnore
+    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+    private Set<Cue> cues = new HashSet<>();
+
     /**
      * Get the id of the project.
      * @return the id
@@ -131,6 +136,14 @@ public class Project implements Serializable {
 
     public void setCameras(Set<Camera> cameras) {
         this.cameras = cameras;
+    }
+
+    public Set<Cue> getCues() {
+        return cues;
+    }
+
+    public void setCues(Set<Cue> cues) {
+        this.cues = cues;
     }
 
     /**

--- a/src/main/java/nl/tudelft/thefirstorder/service/MapService.java
+++ b/src/main/java/nl/tudelft/thefirstorder/service/MapService.java
@@ -4,7 +4,7 @@ import nl.tudelft.thefirstorder.domain.Map;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
-import java.util.List;
+import java.util.Optional;
 
 /**
  * Service Interface for managing Map.
@@ -41,4 +41,20 @@ public interface MapService {
      *  @param id the id of the entity
      */
     void delete(Long id);
+
+    /**
+     * Adds a camera to the Map.
+     * @param mapId Id of the Map
+     * @param cameraId Id of the Camera
+     * @return The updated map
+     */
+    Optional<Map> addCamera(Long mapId, Long cameraId);
+
+    /**
+     * Adds a player to the Map.
+     * @param mapId Id of the Map
+     * @param playerId Id of the Player
+     * @return The updated map
+     */
+    Optional<Map> addPlayer(Long mapId, Long playerId);
 }

--- a/src/main/java/nl/tudelft/thefirstorder/service/impl/MapServiceImpl.java
+++ b/src/main/java/nl/tudelft/thefirstorder/service/impl/MapServiceImpl.java
@@ -2,7 +2,9 @@ package nl.tudelft.thefirstorder.service.impl;
 
 import nl.tudelft.thefirstorder.domain.Map;
 import nl.tudelft.thefirstorder.repository.MapRepository;
+import nl.tudelft.thefirstorder.service.CameraService;
 import nl.tudelft.thefirstorder.service.MapService;
+import nl.tudelft.thefirstorder.service.PlayerService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Page;
@@ -11,6 +13,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.inject.Inject;
+import java.util.Optional;
 
 /**
  * Service Implementation for managing Map.
@@ -23,7 +26,13 @@ public class MapServiceImpl implements MapService {
     
     @Inject
     private MapRepository mapRepository;
-    
+
+    @Inject
+    private CameraService cameraService;
+
+    @Inject
+    private PlayerService playerService;
+
     /**
      * Save a map.
      * 
@@ -71,4 +80,39 @@ public class MapServiceImpl implements MapService {
         log.debug("Request to delete Map : {}", id);
         mapRepository.delete(id);
     }
+
+    /**
+     * Adds a camera to the Map.
+     * @param mapId Id of the Map
+     * @param cameraId Id of the Camera
+     * @return The updated map
+     */
+    public Optional<Map> addCamera(Long mapId, Long cameraId) {
+        Map map = findOne(mapId);
+        return Optional.ofNullable(cameraService.findOne(cameraId))
+                .map(camera -> {
+                    log.debug("Request to add camera {} to map {}", mapId, cameraId);
+                    map.addCamera(camera);
+                    return mapRepository.save(map);
+                });
+    }
+
+    /**
+     * Adds a player to the Map.
+     *
+     * @param mapId    Id of the Map
+     * @param playerId Id of the Player
+     * @return The updated map
+     */
+    @Override
+    public Optional<Map> addPlayer(Long mapId, Long playerId) {
+        Map map = findOne(mapId);
+        return Optional.ofNullable(playerService.findOne(playerId))
+                .map(player -> {
+                    log.debug("Request to add player {} to map {}", mapId, playerId);
+                    map.addPlayer(player);
+                    return mapRepository.save(map);
+                });
+    }
+
 }

--- a/src/main/java/nl/tudelft/thefirstorder/web/rest/MapResource.java
+++ b/src/main/java/nl/tudelft/thefirstorder/web/rest/MapResource.java
@@ -1,7 +1,6 @@
 package nl.tudelft.thefirstorder.web.rest;
 
 import com.codahale.metrics.annotation.Timed;
-import nl.tudelft.thefirstorder.domain.Camera;
 import nl.tudelft.thefirstorder.domain.Map;
 import nl.tudelft.thefirstorder.service.CameraService;
 import nl.tudelft.thefirstorder.service.MapService;
@@ -148,20 +147,40 @@ public class MapResource {
         return ResponseEntity.ok().headers(HeaderUtil.createEntityDeletionAlert("map", id.toString())).build();
     }
 
+    /**
+     * PUT  /maps/{mapId}/addCamera?cameraId={cameraId}
+     * Adds a (existing) camera to the map.
+     * @param mapId Map id
+     * @param cameraId Camera id
+     * @return ResponseEntity with status OK if succeeded, or status 404 if an error occurred.
+     */
     @RequestMapping(value = "/maps/{mapId}/addCamera",
         method = RequestMethod.PUT,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @Timed
     @Transactional
     public ResponseEntity<Map> addCameraToMap(@PathVariable Long mapId, @RequestParam Long cameraId) {
-        Camera camera = cameraService.findOne(cameraId);
-        return Optional.ofNullable(mapService.findOne(mapId))
-                .map(map -> {
-                    map.getCameras();
-                    map.addCamera(camera);
-                    mapService.save(map);
-                    return new ResponseEntity<Map>(map, HttpStatus.OK);
-                }).orElse(new ResponseEntity<Map>(HttpStatus.NOT_FOUND));
+        return mapService.addCamera(mapId, cameraId)
+                .map(map -> new ResponseEntity<>(map, HttpStatus.OK))
+                .orElse(new ResponseEntity<>(HttpStatus.NOT_FOUND));
+    }
+
+    /**
+     * PUT  /maps/{mapId}/addPlayer?playerId={playerId}
+     * Adds a (existing) player to the map.
+     * @param mapId Map id
+     * @param playerId Player id
+     * @return ResponseEntity with status OK if succeeded, or status 404 if an error occurred.
+     */
+    @RequestMapping(value = "/maps/{mapId}/addPlayer",
+            method = RequestMethod.PUT,
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @Timed
+    @Transactional
+    public ResponseEntity<Map> addPlayerToMap(@PathVariable Long mapId, @RequestParam Long playerId) {
+        return mapService.addPlayer(mapId, playerId)
+                .map(map -> new ResponseEntity<>(map, HttpStatus.OK))
+                .orElse(new ResponseEntity<>(HttpStatus.NOT_FOUND));
     }
 
 }

--- a/src/main/java/nl/tudelft/thefirstorder/web/rest/MapResource.java
+++ b/src/main/java/nl/tudelft/thefirstorder/web/rest/MapResource.java
@@ -2,7 +2,6 @@ package nl.tudelft.thefirstorder.web.rest;
 
 import com.codahale.metrics.annotation.Timed;
 import nl.tudelft.thefirstorder.domain.Map;
-import nl.tudelft.thefirstorder.service.CameraService;
 import nl.tudelft.thefirstorder.service.MapService;
 import nl.tudelft.thefirstorder.web.rest.util.HeaderUtil;
 import nl.tudelft.thefirstorder.web.rest.util.PaginationUtil;
@@ -40,9 +39,6 @@ public class MapResource {
     @Inject
     private MapService mapService;
 
-    @Inject
-    private CameraService cameraService;
-    
     /**
      * POST  /maps : Create a new map.
      *

--- a/src/main/resources/config/liquibase/changelog/20160504113134_added_entity_Cue.xml
+++ b/src/main/resources/config/liquibase/changelog/20160504113134_added_entity_Cue.xml
@@ -36,6 +36,9 @@
             <column name="camera_id" type="bigint">
                 <constraints nullable="true"/>
             </column>
+            <column name="project_id" type="bigint">
+                <constraints nullable="true"/>
+            </column>
             <!-- jhipster-needle-liquibase-add-column - Jhipster will add columns here, do not remove-->
         </createTable>
         

--- a/src/main/resources/config/liquibase/changelog/20160504113134_added_entity_constraints_Cue.xml
+++ b/src/main/resources/config/liquibase/changelog/20160504113134_added_entity_constraints_Cue.xml
@@ -38,5 +38,10 @@
                                  referencedColumnNames="id"
                                  referencedTableName="camera"/>
 
+        <addForeignKeyConstraint baseColumnNames="project_id"
+                                 baseTableName="cue"
+                                 constraintName="fk_cue_project_id"
+                                 referencedColumnNames="id"
+                                 referencedTableName="project"/>
     </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/config/liquibase/changelog/20160524154401_added_jointable_map_cameras.xml
+++ b/src/main/resources/config/liquibase/changelog/20160524154401_added_jointable_map_cameras.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+    <changeSet id="20160524154401-1" author="Hung">
+        <createTable tableName="map_cameras">
+            <column name="map_id" type="bigint">
+                <constraints nullable="false"/>
+            </column>
+            <column name="camera_id" type="bigint">
+                <constraints nullable="false"/>
+            </column>
+            <!-- jhipster-needle-liquibase-add-column - Jhipster will add columns here, do not remove-->
+        </createTable>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/changelog/20160524163221_added_jointable_map_players.xml
+++ b/src/main/resources/config/liquibase/changelog/20160524163221_added_jointable_map_players.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+    <changeSet id="20160524163221-1" author="Hung">
+        <createTable tableName="map_players">
+            <column name="map_id" type="bigint">
+                <constraints nullable="false"/>
+            </column>
+            <column name="player_id" type="bigint">
+                <constraints nullable="false"/>
+            </column>
+            <!-- jhipster-needle-liquibase-add-column - Jhipster will add columns here, do not remove-->
+        </createTable>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -16,6 +16,7 @@
     <include file="classpath:config/liquibase/changelog/20160504134055_added_entity_CameraAction.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20160520223310_added_entity_column_User.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20160524154401_added_jointable_map_cameras.xml" relativeToChangelogFile="false"/>
+    <include file="classpath:config/liquibase/changelog/20160524163221_added_jointable_map_players.xml" relativeToChangelogFile="false"/>
     <!-- jhipster-needle-liquibase-add-changelog - JHipster will add liquibase changelogs here -->
     <include file="classpath:config/liquibase/changelog/20160504105827_added_entity_constraints_Project.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20160504113134_added_entity_constraints_Cue.xml" relativeToChangelogFile="false"/>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -15,6 +15,7 @@
     <include file="classpath:config/liquibase/changelog/20160518111537_added_entity_TimePoint.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20160504134055_added_entity_CameraAction.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20160520223310_added_entity_column_User.xml" relativeToChangelogFile="false"/>
+    <include file="classpath:config/liquibase/changelog/20160524154401_added_jointable_map_cameras.xml" relativeToChangelogFile="false"/>
     <!-- jhipster-needle-liquibase-add-changelog - JHipster will add liquibase changelogs here -->
     <include file="classpath:config/liquibase/changelog/20160504105827_added_entity_constraints_Project.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20160504113134_added_entity_constraints_Cue.xml" relativeToChangelogFile="false"/>

--- a/src/main/webapp/app/entities/cue/cue-detail.controller.js
+++ b/src/main/webapp/app/entities/cue/cue-detail.controller.js
@@ -5,9 +5,9 @@
         .module('thefirstorderApp')
         .controller('CueDetailController', CueDetailController);
 
-    CueDetailController.$inject = ['$scope', '$rootScope', '$stateParams', 'entity', 'Cue', 'Script', 'CameraAction', 'TimePoint', 'Player', 'Camera'];
+    CueDetailController.$inject = ['$scope', '$rootScope', '$stateParams', 'entity', 'Cue', 'Script', 'CameraAction', 'TimePoint', 'Player', 'Camera', 'Project'];
 
-    function CueDetailController($scope, $rootScope, $stateParams, entity, Cue, Script, CameraAction, TimePoint, Player, Camera) {
+    function CueDetailController($scope, $rootScope, $stateParams, entity, Cue, Script, CameraAction, TimePoint, Player, Camera, Project) {
         var vm = this;
         vm.cue = entity;
         

--- a/src/main/webapp/app/entities/cue/cue-detail.html
+++ b/src/main/webapp/app/entities/cue/cue-detail.html
@@ -28,6 +28,11 @@
             <a ui-sref="camera-detail({id:vm.cue.camera.id})">{{vm.cue.camera.name}}</a>
         </dd>
         <hr>
+        <dt><span>Project</span></dt>
+        <dd>
+            <a ui-sref="project-detail({id:vm.cue.project.id})">{{vm.cue.project.name}}</a>
+        </dd>
+        <hr>
     </dl>
 
     <button type="submit"

--- a/src/main/webapp/app/entities/cue/cue-dialog.controller.js
+++ b/src/main/webapp/app/entities/cue/cue-dialog.controller.js
@@ -5,13 +5,21 @@
         .module('thefirstorderApp')
         .controller('CueDialogController', CueDialogController);
 
-    CueDialogController.$inject = ['$timeout', '$scope', '$stateParams', '$uibModalInstance', '$q', 'entity', 'Cue', 'Script', 'CameraAction', 'TimePoint', 'Player', 'Camera'];
+    CueDialogController.$inject = ['$timeout', '$scope', '$stateParams', '$uibModalInstance', '$q', 'entity', 'Cue', 'Script', 'CameraAction', 'TimePoint', 'Player', 'Camera', 'Project'];
 
-    function CueDialogController ($timeout, $scope, $stateParams, $uibModalInstance, $q, entity, Cue, Script, CameraAction, TimePoint, Player, Camera) {
+    function CueDialogController ($timeout, $scope, $stateParams, $uibModalInstance, $q, entity, Cue, Script, CameraAction, TimePoint, Player, Camera, Project) {
         var vm = this;
         vm.cue = entity;
         vm.scripts = Script.query();
-        vm.cameraactions = CameraAction.query();
+        vm.cameraactions = CameraAction.query({filter: 'cue-is-null'});
+        $q.all([vm.cue.$promise, vm.cameraactions.$promise]).then(function() {
+            if (!vm.cue.cameraAction || !vm.cue.cameraAction.id) {
+                return $q.reject();
+            }
+            return CameraAction.get({id : vm.cue.cameraAction.id}).$promise;
+        }).then(function(cameraAction) {
+            vm.cameraactions.push(cameraAction);
+        });
         vm.timepoints = TimePoint.query({filter: 'cue-is-null'});
         $q.all([vm.cue.$promise, vm.timepoints.$promise]).then(function() {
             if (!vm.cue.timePoint || !vm.cue.timePoint.id) {
@@ -23,6 +31,7 @@
         });
         vm.players = Player.query();
         vm.cameras = Camera.query();
+        vm.projects = Project.query();
 
         $timeout(function (){
             angular.element('.form-group:eq(1)>input').focus();

--- a/src/main/webapp/app/entities/cue/cue-dialog.html
+++ b/src/main/webapp/app/entities/cue/cue-dialog.html
@@ -44,6 +44,12 @@
                 <option value=""></option>
             </select>
         </div>
+        <div class="form-group">
+            <label for="field_project">Project</label>
+            <select class="form-control" id="field_project" name="project" ng-model="vm.cue.project" ng-options="project as project.name for project in vm.projects track by project.id">
+                <option value=""></option>
+            </select>
+        </div>
     </div>
     <div class="modal-footer">
         <button type="button" class="btn btn-default" data-dismiss="modal" ng-click="vm.clear()">

--- a/src/main/webapp/app/entities/cue/cues.html
+++ b/src/main/webapp/app/entities/cue/cues.html
@@ -27,6 +27,7 @@
                     <th jh-sort-by="camera.name"><span>Camera</span> <span class="glyphicon glyphicon-sort"></span></th>
                     <th jh-sort-by="timePoint.startTime"><span>Start time</span> <span class="glyphicon glyphicon-sort"></span></th>
                     <th jh-sort-by="timePoint.duration"><span>Duration</span> <span class="glyphicon glyphicon-sort"></span></th>
+                    <th jh-sort-by="project.name"><span>Project</span> <span class="glyphicon glyphicon-sort"></span></th>
                     <th></th>
                 </tr>
             </thead>
@@ -44,6 +45,9 @@
                     </td>
                     <td>
                         <a ui-sref="camera-detail({id:cue.camera.id})">{{cue.camera.name}}</a>
+                    </td>
+                    <td>
+                        <a ui-sref="project-detail({id:cue.project.id})">{{cue.project.name}}</a>
                     </td>
                     <td>{{cue.timePoint.startTime}}</td>
                     <td>{{cue.timePoint.duration}}</td>

--- a/src/main/webapp/app/entities/project/project-detail.controller.js
+++ b/src/main/webapp/app/entities/project/project-detail.controller.js
@@ -5,9 +5,9 @@
         .module('thefirstorderApp')
         .controller('ProjectDetailController', ProjectDetailController);
 
-    ProjectDetailController.$inject = ['$scope', '$rootScope', '$stateParams', 'entity', 'Project', 'Script', 'Map', 'Player', 'Camera'];
+    ProjectDetailController.$inject = ['$scope', '$rootScope', '$stateParams', 'entity', 'Project', 'Script', 'Map', 'Player', 'Camera', 'Cue'];
 
-    function ProjectDetailController($scope, $rootScope, $stateParams, entity, Project, Script, Map, Player, Camera) {
+    function ProjectDetailController($scope, $rootScope, $stateParams, entity, Project, Script, Map, Player, Camera, Cue) {
         var vm = this;
         vm.project = entity;
         

--- a/src/main/webapp/app/entities/project/project-dialog.controller.js
+++ b/src/main/webapp/app/entities/project/project-dialog.controller.js
@@ -5,9 +5,9 @@
         .module('thefirstorderApp')
         .controller('ProjectDialogController', ProjectDialogController);
 
-    ProjectDialogController.$inject = ['$timeout', '$scope', '$stateParams', '$uibModalInstance', '$q', 'entity', 'Project', 'Script', 'Map', 'Player', 'Camera'];
+    ProjectDialogController.$inject = ['$timeout', '$scope', '$stateParams', '$uibModalInstance', '$q', 'entity', 'Project', 'Script', 'Map', 'Player', 'Camera', 'Cue'];
 
-    function ProjectDialogController ($timeout, $scope, $stateParams, $uibModalInstance, $q, entity, Project, Script, Map, Player, Camera) {
+    function ProjectDialogController ($timeout, $scope, $stateParams, $uibModalInstance, $q, entity, Project, Script, Map, Player, Camera, Cue) {
         var vm = this;
         vm.project = entity;
         vm.scripts = Script.query({filter: 'project-is-null'});
@@ -30,6 +30,7 @@
         });
         vm.players = Player.query();
         vm.cameras = Camera.query();
+        vm.cues = Cue.query();
 
         $timeout(function (){
             angular.element('.form-group:eq(1)>input').focus();

--- a/src/test/java/nl/tudelft/thefirstorder/web/rest/MapJoinTableResourceIntTest.java
+++ b/src/test/java/nl/tudelft/thefirstorder/web/rest/MapJoinTableResourceIntTest.java
@@ -1,0 +1,158 @@
+package nl.tudelft.thefirstorder.web.rest;
+
+import nl.tudelft.thefirstorder.ThefirstorderApp;
+import nl.tudelft.thefirstorder.domain.Camera;
+import nl.tudelft.thefirstorder.domain.Map;
+import nl.tudelft.thefirstorder.domain.Player;
+import nl.tudelft.thefirstorder.repository.CameraRepository;
+import nl.tudelft.thefirstorder.repository.MapRepository;
+import nl.tudelft.thefirstorder.repository.PlayerRepository;
+import nl.tudelft.thefirstorder.service.CameraService;
+import nl.tudelft.thefirstorder.service.MapService;
+import nl.tudelft.thefirstorder.service.PlayerService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.MockitoAnnotations;
+import org.springframework.boot.test.IntegrationTest;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+/**
+ * Test class for the MapResource REST controller.
+ *
+ * @see MapResource
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = ThefirstorderApp.class)
+@WebAppConfiguration
+@IntegrationTest
+public class MapJoinTableResourceIntTest {
+
+    private static final String DEFAULT_MAP_NAME = "AAAAA";
+    private static final String UPDATED_MAP_NAME = "BBBBB";
+    private static final String DEFAULT_CAMERA_NAME = "CCCCC";
+    private static final String DEFAULT_PLAYER_NAME = "DDDDD";
+
+    @Inject
+    private MapRepository mapRepository;
+
+    @Inject
+    private PlayerRepository playerRepository;
+
+    @Inject
+    private CameraRepository cameraRepository;
+
+    @Inject
+    private MapService mapService;
+
+    @Inject
+    private MappingJackson2HttpMessageConverter jacksonMessageConverter;
+
+    @Inject
+    private PageableHandlerMethodArgumentResolver pageableArgumentResolver;
+
+    private MockMvc restMapMockMvc;
+
+    private Map map;
+
+    @PostConstruct
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        MapResource mapResource = new MapResource();
+        ReflectionTestUtils.setField(mapResource, "mapService", mapService);
+        this.restMapMockMvc = MockMvcBuilders.standaloneSetup(mapResource)
+            .setCustomArgumentResolvers(pageableArgumentResolver)
+            .setMessageConverters(jacksonMessageConverter).build();
+    }
+
+    @Before
+    public void initTest() {
+        map = new Map();
+        map.setName(DEFAULT_MAP_NAME);
+    }
+
+    @Test
+    @Transactional
+    public void addCamera() throws Exception {
+        Camera camera = new Camera();
+        camera.setName(DEFAULT_CAMERA_NAME);
+
+        // Initialize the database
+        cameraRepository.saveAndFlush(camera);
+        mapRepository.saveAndFlush(map);
+
+        // Get the map
+        restMapMockMvc.perform(put("/api/maps/{id}/addCamera", map.getId())
+                .param("cameraId", camera.getId().toString()))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.id").value(map.getId().intValue()))
+                .andExpect(jsonPath("$.name").value(DEFAULT_MAP_NAME))
+                .andExpect(jsonPath("$.cameras[0].id").value(camera.getId().intValue()))
+                .andExpect(jsonPath("$.cameras[0].name").value(DEFAULT_CAMERA_NAME));
+    }
+
+    @Test
+    @Transactional
+    public void addPlayer() throws Exception {
+        Player player = new Player();
+        player.setName(DEFAULT_PLAYER_NAME);
+
+        // Initialize the database
+        playerRepository.saveAndFlush(player);
+        mapRepository.saveAndFlush(map);
+
+        // Get the map
+        restMapMockMvc.perform(put("/api/maps/{id}/addPlayer", map.getId())
+                .param("playerId", player.getId().toString()))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.id").value(map.getId().intValue()))
+                .andExpect(jsonPath("$.name").value(DEFAULT_MAP_NAME))
+                .andExpect(jsonPath("$.players[0].id").value(player.getId().intValue()))
+                .andExpect(jsonPath("$.players[0].name").value(DEFAULT_PLAYER_NAME));
+    }
+
+    @Test
+    @Transactional
+    public void addInvalidCamera() throws Exception {
+        // Initialize the database
+        mapRepository.saveAndFlush(map);
+
+        // Get the map
+        restMapMockMvc.perform(put("/api/maps/{id}/addCamera", map.getId())
+                .param("cameraId", "0"))
+                .andExpect(status().isNotFound());
+    }
+
+
+    @Test
+    @Transactional
+    public void addInvalidPlayer() throws Exception {
+        // Initialize the database
+        mapRepository.saveAndFlush(map);
+
+        // Get the map
+        restMapMockMvc.perform(put("/api/maps/{id}/addPlayer", map.getId())
+                .param("playerId", "0"))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/src/test/javascript/spec/app/entities/cue/cue-detail.controller.spec.js
+++ b/src/test/javascript/spec/app/entities/cue/cue-detail.controller.spec.js
@@ -4,7 +4,7 @@ describe('Controller Tests', function() {
 
     describe('Cue Management Detail Controller', function() {
         var $scope, $rootScope;
-        var MockEntity, MockCue, MockScript, MockCameraAction, MockTimePoint, MockPlayer, MockCamera;
+        var MockEntity, MockCue, MockScript, MockCameraAction, MockTimePoint, MockPlayer, MockCamera, MockProject;
         var createController;
 
         beforeEach(inject(function($injector) {
@@ -17,6 +17,7 @@ describe('Controller Tests', function() {
             MockTimePoint = jasmine.createSpy('MockTimePoint');
             MockPlayer = jasmine.createSpy('MockPlayer');
             MockCamera = jasmine.createSpy('MockCamera');
+            MockProject = jasmine.createSpy('MockProject');
             
 
             var locals = {
@@ -28,7 +29,8 @@ describe('Controller Tests', function() {
                 'CameraAction': MockCameraAction,
                 'TimePoint': MockTimePoint,
                 'Player': MockPlayer,
-                'Camera': MockCamera
+                'Camera': MockCamera,
+                'Project': MockProject
             };
             createController = function() {
                 $injector.get('$controller')("CueDetailController", locals);

--- a/src/test/javascript/spec/app/entities/project/project-detail.controller.spec.js
+++ b/src/test/javascript/spec/app/entities/project/project-detail.controller.spec.js
@@ -4,7 +4,7 @@ describe('Controller Tests', function() {
 
     describe('Project Management Detail Controller', function() {
         var $scope, $rootScope;
-        var MockEntity, MockProject, MockScript, MockMap, MockPlayer, MockCamera;
+        var MockEntity, MockProject, MockScript, MockMap, MockPlayer, MockCamera, MockCue;
         var createController;
 
         beforeEach(inject(function($injector) {
@@ -16,6 +16,7 @@ describe('Controller Tests', function() {
             MockMap = jasmine.createSpy('MockMap');
             MockPlayer = jasmine.createSpy('MockPlayer');
             MockCamera = jasmine.createSpy('MockCamera');
+            MockCue = jasmine.createSpy('MockCue');
             
 
             var locals = {
@@ -26,7 +27,8 @@ describe('Controller Tests', function() {
                 'Script': MockScript,
                 'Map': MockMap,
                 'Player': MockPlayer,
-                'Camera': MockCamera
+                'Camera': MockCamera,
+                'Cue': MockCue
             };
             createController = function() {
                 $injector.get('$controller')("ProjectDetailController", locals);


### PR DESCRIPTION
Project now has a one-to-many relationship with Cue. 

Map can now also contain Player and Camera objects. This is an uni-directional relationship and uses a join table. The Player and Camera class don't have a reference to a Map. Instead, a separate table is used, containing the Map id and Player/Camera id that belong together. 

I added a method in the service class to add cameras and players to a map. I also created the URI mapping for it. 