### PR TITLE
Add tests for entity classes.

### DIFF
--- a/src/test/java/nl/tudelft/thefirstorder/domain/AuthorityTest.java
+++ b/src/test/java/nl/tudelft/thefirstorder/domain/AuthorityTest.java
@@ -1,0 +1,79 @@
+package nl.tudelft.thefirstorder.domain;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AuthorityTest {
+
+    private Authority entity;
+
+    private static long DEFAULT_ID = 1L;
+    private static String DEFAULT_NAME = "AAAAA";
+
+    @Before
+    public void setUp() throws Exception {
+        entity = new Authority();
+    }
+
+    @Test
+    public void getName() throws Exception {
+        entity.setName(DEFAULT_NAME);
+        assertThat(entity.getName()).isEqualTo(DEFAULT_NAME);
+    }
+
+    @Test
+    public void equalsBranch1() throws Exception {
+        assertThat(entity.equals(entity)).isTrue();
+    }
+
+    @Test
+    public void equalsBranch2() throws Exception {
+        assertThat(entity.equals(null)).isFalse();
+    }
+
+    @Test
+    public void equalsBranch3() throws Exception {
+        assertThat(entity.equals(new Object())).isFalse();
+    }
+
+    @Test
+    public void equalsBranch4() throws Exception {
+        entity.setName(DEFAULT_NAME);
+        Authority entity2 = new Authority();
+        entity2.setName(entity.getName());
+        assertThat(entity.equals(entity2)).isTrue();
+    }
+
+    @Test
+    public void equalsBranch5() throws Exception {
+        entity.setName(DEFAULT_NAME);
+        Authority entity2 = new Authority();
+        assertThat(entity.equals(entity2)).isFalse();
+    }
+
+    @Test
+    public void equalsBranch6() throws Exception {
+        Authority entity2 = new Authority();
+        entity2.setName(DEFAULT_NAME);
+        assertThat(entity.equals(entity2)).isFalse();
+    }
+
+    @Test
+    public void hashCodeTest() throws Exception {
+        Authority entity2 = new Authority();
+        entity.setName(DEFAULT_NAME);
+        entity2.setName(DEFAULT_NAME);
+        assertThat(entity.hashCode() == entity2.hashCode());
+    }
+
+    @Test
+    public void toStringTest() throws Exception {
+        Authority entity2 = new Authority();
+        assertThat(Objects.equals(entity.toString(), entity2.toString()));
+    }
+
+}

--- a/src/test/java/nl/tudelft/thefirstorder/domain/CameraActionTest.java
+++ b/src/test/java/nl/tudelft/thefirstorder/domain/CameraActionTest.java
@@ -1,0 +1,86 @@
+package nl.tudelft.thefirstorder.domain;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CameraActionTest {
+
+    private CameraAction entity;
+
+    private static long DEFAULT_ID = 1L;
+    private static String DEFAULT_NAME = "AAAAA";
+
+    @Before
+    public void setUp() throws Exception {
+        entity = new CameraAction();
+    }
+
+    @Test
+    public void getId() throws Exception {
+        entity.setId(DEFAULT_ID);
+        assertThat(entity.getId()).isEqualTo(DEFAULT_ID);
+    }
+
+    @Test
+    public void getName() throws Exception {
+        entity.setName(DEFAULT_NAME);
+        assertThat(entity.getName()).isEqualTo(DEFAULT_NAME);
+    }
+
+
+    @Test
+    public void equalsBranch1() throws Exception {
+        assertThat(entity.equals(entity)).isTrue();
+    }
+
+    @Test
+    public void equalsBranch2() throws Exception {
+        assertThat(entity.equals(null)).isFalse();
+    }
+
+    @Test
+    public void equalsBranch3() throws Exception {
+        assertThat(entity.equals(new Object())).isFalse();
+    }
+
+    @Test
+    public void equalsBranch4() throws Exception {
+        entity.setId(DEFAULT_ID);
+        CameraAction entity2 = new CameraAction();
+        entity2.setId(entity.getId());
+        assertThat(entity.equals(entity2)).isTrue();
+    }
+
+    @Test
+    public void equalsBranch5() throws Exception {
+        entity.setId(DEFAULT_ID);
+        CameraAction entity2 = new CameraAction();
+        assertThat(entity.equals(entity2)).isFalse();
+    }
+
+    @Test
+    public void equalsBranch6() throws Exception {
+        CameraAction entity2 = new CameraAction();
+        entity2.setId(DEFAULT_ID);
+        assertThat(entity.equals(entity2)).isFalse();
+    }
+
+    @Test
+    public void hashCodeTest() throws Exception {
+        CameraAction entity2 = new CameraAction();
+        entity.setId(DEFAULT_ID);
+        entity2.setId(DEFAULT_ID);
+        assertThat(entity.hashCode() == entity2.hashCode());
+    }
+
+    @Test
+    public void toStringTest() throws Exception {
+        CameraAction entity2 = new CameraAction();
+        assertThat(Objects.equals(entity.toString(), entity2.toString()));
+    }
+
+}

--- a/src/test/java/nl/tudelft/thefirstorder/domain/CameraTest.java
+++ b/src/test/java/nl/tudelft/thefirstorder/domain/CameraTest.java
@@ -1,0 +1,97 @@
+package nl.tudelft.thefirstorder.domain;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CameraTest {
+
+    private Camera entity;
+
+    private static long DEFAULT_ID = 1L;
+    private static String DEFAULT_NAME = "AAAAA";
+
+    @Before
+    public void setUp() throws Exception {
+        entity = new Camera();
+    }
+
+    @Test
+    public void getId() throws Exception {
+        entity.setId(DEFAULT_ID);
+        assertThat(entity.getId()).isEqualTo(DEFAULT_ID);
+    }
+
+    @Test
+    public void getName() throws Exception {
+        entity.setName(DEFAULT_NAME);
+        assertThat(entity.getName()).isEqualTo(DEFAULT_NAME);
+    }
+
+    @Test
+    public void getX() throws Exception {
+        entity.setX(1);
+        assertThat(entity.getX()).isEqualTo(1);
+    }
+
+    @Test
+    public void getY() throws Exception {
+        entity.setY(1);
+        assertThat(entity.getY()).isEqualTo(1);
+    }
+
+    @Test
+    public void equalsBranch1() throws Exception {
+        assertThat(entity.equals(entity)).isTrue();
+    }
+
+    @Test
+    public void equalsBranch2() throws Exception {
+        assertThat(entity.equals(null)).isFalse();
+    }
+
+    @Test
+    public void equalsBranch3() throws Exception {
+        assertThat(entity.equals(new Object())).isFalse();
+    }
+
+    @Test
+    public void equalsBranch4() throws Exception {
+        entity.setId(DEFAULT_ID);
+        Camera entity2 = new Camera();
+        entity2.setId(entity.getId());
+        assertThat(entity.equals(entity2)).isTrue();
+    }
+
+    @Test
+    public void equalsBranch5() throws Exception {
+        entity.setId(DEFAULT_ID);
+        Camera entity2 = new Camera();
+        assertThat(entity.equals(entity2)).isFalse();
+    }
+
+    @Test
+    public void equalsBranch6() throws Exception {
+        Camera entity2 = new Camera();
+        entity2.setId(DEFAULT_ID);
+        assertThat(entity.equals(entity2)).isFalse();
+    }
+
+    @Test
+    public void hashCodeTest() throws Exception {
+        Camera entity2 = new Camera();
+        entity.setId(DEFAULT_ID);
+        entity2.setId(DEFAULT_ID);
+        assertThat(entity.hashCode() == entity2.hashCode());
+    }
+
+    @Test
+    public void toStringTest() throws Exception {
+        Camera entity2 = new Camera();
+        assertThat(Objects.equals(entity.toString(), entity2.toString()));
+    }
+
+}

--- a/src/test/java/nl/tudelft/thefirstorder/domain/MapTest.java
+++ b/src/test/java/nl/tudelft/thefirstorder/domain/MapTest.java
@@ -1,0 +1,86 @@
+package nl.tudelft.thefirstorder.domain;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MapTest {
+
+    private Map entity;
+
+    private static long DEFAULT_ID = 1L;
+    private static String DEFAULT_NAME = "AAAAA";
+
+    @Before
+    public void setUp() throws Exception {
+        entity = new Map();
+    }
+
+    @Test
+    public void getId() throws Exception {
+        entity.setId(DEFAULT_ID);
+        assertThat(entity.getId()).isEqualTo(DEFAULT_ID);
+    }
+
+    @Test
+    public void getName() throws Exception {
+        entity.setName(DEFAULT_NAME);
+        assertThat(entity.getName()).isEqualTo(DEFAULT_NAME);
+    }
+
+
+    @Test
+    public void equalsBranch1() throws Exception {
+        assertThat(entity.equals(entity)).isTrue();
+    }
+
+    @Test
+    public void equalsBranch2() throws Exception {
+        assertThat(entity.equals(null)).isFalse();
+    }
+
+    @Test
+    public void equalsBranch3() throws Exception {
+        assertThat(entity.equals(new Object())).isFalse();
+    }
+
+    @Test
+    public void equalsBranch4() throws Exception {
+        entity.setId(DEFAULT_ID);
+        Map entity2 = new Map();
+        entity2.setId(entity.getId());
+        assertThat(entity.equals(entity2)).isTrue();
+    }
+
+    @Test
+    public void equalsBranch5() throws Exception {
+        entity.setId(DEFAULT_ID);
+        Map entity2 = new Map();
+        assertThat(entity.equals(entity2)).isFalse();
+    }
+
+    @Test
+    public void equalsBranch6() throws Exception {
+        Map entity2 = new Map();
+        entity2.setId(DEFAULT_ID);
+        assertThat(entity.equals(entity2)).isFalse();
+    }
+
+    @Test
+    public void hashCodeTest() throws Exception {
+        Map entity2 = new Map();
+        entity.setId(DEFAULT_ID);
+        entity2.setId(DEFAULT_ID);
+        assertThat(entity.hashCode() == entity2.hashCode());
+    }
+
+    @Test
+    public void toStringTest() throws Exception {
+        Map entity2 = new Map();
+        assertThat(Objects.equals(entity.toString(), entity2.toString()));
+    }
+
+}

--- a/src/test/java/nl/tudelft/thefirstorder/domain/PlayerTest.java
+++ b/src/test/java/nl/tudelft/thefirstorder/domain/PlayerTest.java
@@ -1,0 +1,97 @@
+package nl.tudelft.thefirstorder.domain;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PlayerTest {
+
+    private Player entity;
+
+    private static long DEFAULT_ID = 1L;
+    private static String DEFAULT_NAME = "AAAAA";
+
+    @Before
+    public void setUp() throws Exception {
+        entity = new Player();
+    }
+
+    @Test
+    public void getId() throws Exception {
+        entity.setId(DEFAULT_ID);
+        assertThat(entity.getId()).isEqualTo(DEFAULT_ID);
+    }
+
+    @Test
+    public void getName() throws Exception {
+        entity.setName(DEFAULT_NAME);
+        assertThat(entity.getName()).isEqualTo(DEFAULT_NAME);
+    }
+
+    @Test
+    public void getX() throws Exception {
+        entity.setX(1);
+        assertThat(entity.getX()).isEqualTo(1);
+    }
+
+    @Test
+    public void getY() throws Exception {
+        entity.setY(1);
+        assertThat(entity.getY()).isEqualTo(1);
+    }
+
+    @Test
+    public void equalsBranch1() throws Exception {
+        assertThat(entity.equals(entity)).isTrue();
+    }
+
+    @Test
+    public void equalsBranch2() throws Exception {
+        assertThat(entity.equals(null)).isFalse();
+    }
+
+    @Test
+    public void equalsBranch3() throws Exception {
+        assertThat(entity.equals(new Object())).isFalse();
+    }
+
+    @Test
+    public void equalsBranch4() throws Exception {
+        entity.setId(DEFAULT_ID);
+        Player entity2 = new Player();
+        entity2.setId(entity.getId());
+        assertThat(entity.equals(entity2)).isTrue();
+    }
+
+    @Test
+    public void equalsBranch5() throws Exception {
+        entity.setId(DEFAULT_ID);
+        Player entity2 = new Player();
+        assertThat(entity.equals(entity2)).isFalse();
+    }
+
+    @Test
+    public void equalsBranch6() throws Exception {
+        Player entity2 = new Player();
+        entity2.setId(DEFAULT_ID);
+        assertThat(entity.equals(entity2)).isFalse();
+    }
+
+    @Test
+    public void hashCodeTest() throws Exception {
+        Player entity2 = new Player();
+        entity.setId(DEFAULT_ID);
+        entity2.setId(DEFAULT_ID);
+        assertThat(entity.hashCode() == entity2.hashCode());
+    }
+
+    @Test
+    public void toStringTest() throws Exception {
+        Player entity2 = new Player();
+        assertThat(Objects.equals(entity.toString(), entity2.toString()));
+    }
+
+}

--- a/src/test/java/nl/tudelft/thefirstorder/domain/ProjectTest.java
+++ b/src/test/java/nl/tudelft/thefirstorder/domain/ProjectTest.java
@@ -1,0 +1,86 @@
+package nl.tudelft.thefirstorder.domain;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ProjectTest {
+
+    private Project entity;
+
+    private static long DEFAULT_ID = 1L;
+    private static String DEFAULT_NAME = "AAAAA";
+
+    @Before
+    public void setUp() throws Exception {
+        entity = new Project();
+    }
+
+    @Test
+    public void getId() throws Exception {
+        entity.setId(DEFAULT_ID);
+        assertThat(entity.getId()).isEqualTo(DEFAULT_ID);
+    }
+
+    @Test
+    public void getName() throws Exception {
+        entity.setName(DEFAULT_NAME);
+        assertThat(entity.getName()).isEqualTo(DEFAULT_NAME);
+    }
+
+
+    @Test
+    public void equalsBranch1() throws Exception {
+        assertThat(entity.equals(entity)).isTrue();
+    }
+
+    @Test
+    public void equalsBranch2() throws Exception {
+        assertThat(entity.equals(null)).isFalse();
+    }
+
+    @Test
+    public void equalsBranch3() throws Exception {
+        assertThat(entity.equals(new Object())).isFalse();
+    }
+
+    @Test
+    public void equalsBranch4() throws Exception {
+        entity.setId(DEFAULT_ID);
+        Project entity2 = new Project();
+        entity2.setId(entity.getId());
+        assertThat(entity.equals(entity2)).isTrue();
+    }
+
+    @Test
+    public void equalsBranch5() throws Exception {
+        entity.setId(DEFAULT_ID);
+        Project entity2 = new Project();
+        assertThat(entity.equals(entity2)).isFalse();
+    }
+
+    @Test
+    public void equalsBranch6() throws Exception {
+        Project entity2 = new Project();
+        entity2.setId(DEFAULT_ID);
+        assertThat(entity.equals(entity2)).isFalse();
+    }
+
+    @Test
+    public void hashCodeTest() throws Exception {
+        Project entity2 = new Project();
+        entity.setId(DEFAULT_ID);
+        entity2.setId(DEFAULT_ID);
+        assertThat(entity.hashCode() == entity2.hashCode());
+    }
+
+    @Test
+    public void toStringTest() throws Exception {
+        Project entity2 = new Project();
+        assertThat(Objects.equals(entity.toString(), entity2.toString()));
+    }
+
+}

--- a/src/test/java/nl/tudelft/thefirstorder/domain/ScriptTest.java
+++ b/src/test/java/nl/tudelft/thefirstorder/domain/ScriptTest.java
@@ -1,0 +1,86 @@
+package nl.tudelft.thefirstorder.domain;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ScriptTest {
+
+    private Script entity;
+
+    private static long DEFAULT_ID = 1L;
+    private static String DEFAULT_NAME = "AAAAA";
+
+    @Before
+    public void setUp() throws Exception {
+        entity = new Script();
+    }
+
+    @Test
+    public void getId() throws Exception {
+        entity.setId(DEFAULT_ID);
+        assertThat(entity.getId()).isEqualTo(DEFAULT_ID);
+    }
+
+    @Test
+    public void getName() throws Exception {
+        entity.setName(DEFAULT_NAME);
+        assertThat(entity.getName()).isEqualTo(DEFAULT_NAME);
+    }
+
+
+    @Test
+    public void equalsBranch1() throws Exception {
+        assertThat(entity.equals(entity)).isTrue();
+    }
+
+    @Test
+    public void equalsBranch2() throws Exception {
+        assertThat(entity.equals(null)).isFalse();
+    }
+
+    @Test
+    public void equalsBranch3() throws Exception {
+        assertThat(entity.equals(new Object())).isFalse();
+    }
+
+    @Test
+    public void equalsBranch4() throws Exception {
+        entity.setId(DEFAULT_ID);
+        Script entity2 = new Script();
+        entity2.setId(entity.getId());
+        assertThat(entity.equals(entity2)).isTrue();
+    }
+
+    @Test
+    public void equalsBranch5() throws Exception {
+        entity.setId(DEFAULT_ID);
+        Script entity2 = new Script();
+        assertThat(entity.equals(entity2)).isFalse();
+    }
+
+    @Test
+    public void equalsBranch6() throws Exception {
+        Script entity2 = new Script();
+        entity2.setId(DEFAULT_ID);
+        assertThat(entity.equals(entity2)).isFalse();
+    }
+
+    @Test
+    public void hashCodeTest() throws Exception {
+        Script entity2 = new Script();
+        entity.setId(DEFAULT_ID);
+        entity2.setId(DEFAULT_ID);
+        assertThat(entity.hashCode() == entity2.hashCode());
+    }
+
+    @Test
+    public void toStringTest() throws Exception {
+        Script entity2 = new Script();
+        assertThat(Objects.equals(entity.toString(), entity2.toString()));
+    }
+
+}

--- a/src/test/java/nl/tudelft/thefirstorder/domain/TimePointTest.java
+++ b/src/test/java/nl/tudelft/thefirstorder/domain/TimePointTest.java
@@ -1,0 +1,91 @@
+package nl.tudelft.thefirstorder.domain;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TimePointTest {
+
+    private TimePoint entity;
+
+    private static long DEFAULT_ID = 1L;
+    private static int DEFAULT_TIME = 11111;
+
+    @Before
+    public void setUp() throws Exception {
+        entity = new TimePoint();
+    }
+
+    @Test
+    public void durationTest() throws Exception {
+        entity.setDuration(DEFAULT_TIME);
+        assertThat(entity.getDuration()).isEqualTo(DEFAULT_TIME);
+    }
+
+    @Test
+    public void startTimeTest() throws Exception {
+        entity.setStartTime(DEFAULT_TIME);
+        assertThat(entity.getStartTime()).isEqualTo(DEFAULT_TIME);
+    }
+
+    @Test
+    public void getId() throws Exception {
+        entity.setId(DEFAULT_ID);
+        assertThat(entity.getId()).isEqualTo(DEFAULT_ID);
+    }
+
+    @Test
+    public void equalsBranch1() throws Exception {
+        assertThat(entity.equals(entity)).isTrue();
+    }
+
+    @Test
+    public void equalsBranch2() throws Exception {
+        assertThat(entity.equals(null)).isFalse();
+    }
+
+    @Test
+    public void equalsBranch3() throws Exception {
+        assertThat(entity.equals(new Object())).isFalse();
+    }
+
+    @Test
+    public void equalsBranch4() throws Exception {
+        entity.setId(DEFAULT_ID);
+        TimePoint entity2 = new TimePoint();
+        entity2.setId(entity.getId());
+        assertThat(entity.equals(entity2)).isTrue();
+    }
+
+    @Test
+    public void equalsBranch5() throws Exception {
+        entity.setId(DEFAULT_ID);
+        TimePoint entity2 = new TimePoint();
+        assertThat(entity.equals(entity2)).isFalse();
+    }
+
+    @Test
+    public void equalsBranch6() throws Exception {
+        TimePoint entity2 = new TimePoint();
+        entity2.setId(DEFAULT_ID);
+        assertThat(entity.equals(entity2)).isFalse();
+    }
+
+    @Test
+    public void hashCodeTest() throws Exception {
+        TimePoint entity2 = new TimePoint();
+        entity.setId(DEFAULT_ID);
+        entity2.setId(DEFAULT_ID);
+        assertThat(entity.hashCode() == entity2.hashCode());
+    }
+
+    @Test
+    public void toStringTest() throws Exception {
+        TimePoint entity2 = new TimePoint();
+        assertThat(Objects.equals(entity.toString(), entity2.toString()));
+    }
+
+}

--- a/src/test/java/nl/tudelft/thefirstorder/domain/UserTest.java
+++ b/src/test/java/nl/tudelft/thefirstorder/domain/UserTest.java
@@ -12,7 +12,8 @@ public class UserTest {
     private User entity;
 
     private static long DEFAULT_ID = 1L;
-    private static String DEFAULT_NAME = "AAAAA";
+    private static String DEFAULT_LOGIN = "AAAAA";
+    private static String OTHER_LOGIN = "BBBBB";
 
     @Before
     public void setUp() throws Exception {
@@ -42,31 +43,32 @@ public class UserTest {
 
     @Test
     public void equalsBranch4() throws Exception {
-        entity.setId(DEFAULT_ID);
+        entity.setLogin(DEFAULT_LOGIN);
         User entity2 = new User();
-        entity2.setId(entity.getId());
+        entity2.setLogin(DEFAULT_LOGIN);
         assertThat(entity.equals(entity2)).isTrue();
     }
 
     @Test
     public void equalsBranch5() throws Exception {
-        entity.setId(DEFAULT_ID);
+        entity.setLogin(DEFAULT_LOGIN);
         User entity2 = new User();
         assertThat(entity.equals(entity2)).isFalse();
     }
 
     @Test
     public void equalsBranch6() throws Exception {
+        entity.setLogin(OTHER_LOGIN);
         User entity2 = new User();
-        entity2.setId(DEFAULT_ID);
+        entity2.setLogin(DEFAULT_LOGIN);
         assertThat(entity.equals(entity2)).isFalse();
     }
 
     @Test
     public void hashCodeTest() throws Exception {
         User entity2 = new User();
-        entity.setId(DEFAULT_ID);
-        entity2.setId(DEFAULT_ID);
+        entity.setLogin(DEFAULT_LOGIN);
+        entity2.setLogin(DEFAULT_LOGIN);
         assertThat(entity.hashCode() == entity2.hashCode());
     }
 

--- a/src/test/java/nl/tudelft/thefirstorder/domain/UserTest.java
+++ b/src/test/java/nl/tudelft/thefirstorder/domain/UserTest.java
@@ -1,0 +1,79 @@
+package nl.tudelft.thefirstorder.domain;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UserTest {
+
+    private User entity;
+
+    private static long DEFAULT_ID = 1L;
+    private static String DEFAULT_NAME = "AAAAA";
+
+    @Before
+    public void setUp() throws Exception {
+        entity = new User();
+    }
+
+    @Test
+    public void getId() throws Exception {
+        entity.setId(DEFAULT_ID);
+        assertThat(entity.getId()).isEqualTo(DEFAULT_ID);
+    }
+
+    @Test
+    public void equalsBranch1() throws Exception {
+        assertThat(entity.equals(entity)).isTrue();
+    }
+
+    @Test
+    public void equalsBranch2() throws Exception {
+        assertThat(entity.equals(null)).isFalse();
+    }
+
+    @Test
+    public void equalsBranch3() throws Exception {
+        assertThat(entity.equals(new Object())).isFalse();
+    }
+
+    @Test
+    public void equalsBranch4() throws Exception {
+        entity.setId(DEFAULT_ID);
+        User entity2 = new User();
+        entity2.setId(entity.getId());
+        assertThat(entity.equals(entity2)).isTrue();
+    }
+
+    @Test
+    public void equalsBranch5() throws Exception {
+        entity.setId(DEFAULT_ID);
+        User entity2 = new User();
+        assertThat(entity.equals(entity2)).isFalse();
+    }
+
+    @Test
+    public void equalsBranch6() throws Exception {
+        User entity2 = new User();
+        entity2.setId(DEFAULT_ID);
+        assertThat(entity.equals(entity2)).isFalse();
+    }
+
+    @Test
+    public void hashCodeTest() throws Exception {
+        User entity2 = new User();
+        entity.setId(DEFAULT_ID);
+        entity2.setId(DEFAULT_ID);
+        assertThat(entity.hashCode() == entity2.hashCode());
+    }
+
+    @Test
+    public void toStringTest() throws Exception {
+        User entity2 = new User();
+        assertThat(Objects.equals(entity.toString(), entity2.toString()));
+    }
+
+}


### PR DESCRIPTION
This adds a lot of tests for the entity classes. This will increase line coverage and branch coverage. 

Low branch coverage was caused by the `.equals()` method in all entities. I've covered all branches in this method, so branch coverage should be much better than before now. 