### PR TITLE
Only let Travis build pushes to dev, stable and fix branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,12 @@ jdk:
   - oraclejdk8
 sudo: false
 
+branches: 
+    only: 
+    - dev
+    - stable
+    - /^fix.*$/
+
 before_cache:
   - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
 cache:


### PR DESCRIPTION
Let Travis be enabled for all pull requests, but only build pushes to `dev`, `stable` and `fix/*` branches. 
Pushes to `dev` must be enabled in order for Coveralls to update the coverage correctly, it seems.