### PR TITLE
Fixed map-editor routing

### DIFF
--- a/src/main/webapp/app/map/map-editor.state.js
+++ b/src/main/webapp/app/map/map-editor.state.js
@@ -10,7 +10,7 @@
     function stateConfig($stateProvider) {
         $stateProvider.state('map-editor', {
             parent: 'app',
-            url: '/mapeditor',
+            url: '/map-editor',
             data: {
                 authorities: ['ROLE_USER']
             },

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -11,7 +11,7 @@
     <!-- bower:css -->
     <link rel="stylesheet" href="bower_components/angular-loading-bar/build/loading-bar.css" />
     <link rel="stylesheet" href="bower_components/bootstrap/dist/css/bootstrap.css" />
-    <link rel="stylesheet" href="bower_components/vis/dist/vis.css" />
+    <link rel="stylesheet" href="bower_components/vis/dist/vis.min.css" />
     <!-- endbower -->
     <!-- endbuild -->
     <!-- build:css content/css/main.css -->
@@ -70,7 +70,8 @@
     <script src="bower_components/blob-polyfill/Blob.js"></script>
     <script src="bower_components/file-saver.js/FileSaver.js"></script>
     <script src="bower_components/angular-file-saver/dist/angular-file-saver.bundle.js"></script>
-    <script src="bower_components/vis/dist/vis.js"></script>
+    <script src="bower_components/vis/dist/vis.min.js"></script>
+    <script src="bower_components/angular-animate/angular-animate.js"></script>
     <!-- endbower -->
     <!-- endbuild -->
 
@@ -81,6 +82,15 @@
     <script src="app/account/reset/request/reset.request.controller.js"></script>
     <script src="app/account/reset/finish/reset.finish.state.js"></script>
     <script src="app/account/reset/finish/reset.finish.controller.js"></script>
+    <script src="app/blocks/interceptor/notification.interceptor.js"></script>
+    <script src="app/blocks/interceptor/errorhandler.interceptor.js"></script>
+    <script src="app/blocks/interceptor/auth.interceptor.js"></script>
+    <script src="app/blocks/interceptor/auth-expired.interceptor.js"></script>
+    <script src="app/blocks/handlers/state.handler.js"></script>
+    <script src="app/blocks/config/localstorage.config.js"></script>
+    <script src="app/blocks/config/http.config.js"></script>
+    <script src="app/blocks/config/compile.config.js"></script>
+    <script src="app/blocks/config/alert.config.js"></script>
     <script src="app/services/user/user.service.js"></script>
     <script src="app/services/user/project-manager.service.js"></script>
     <script src="app/services/auth/register.service.js"></script>
@@ -169,20 +179,15 @@
     <script src="app/components/alert/alert.service.js"></script>
     <script src="app/components/alert/alert.directive.js"></script>
     <script src="app/components/alert/alert-error.directive.js"></script>
-    <script src="app/blocks/interceptor/notification.interceptor.js"></script>
-    <script src="app/blocks/interceptor/errorhandler.interceptor.js"></script>
-    <script src="app/blocks/interceptor/auth.interceptor.js"></script>
-    <script src="app/blocks/interceptor/auth-expired.interceptor.js"></script>
-    <script src="app/blocks/handlers/state.handler.js"></script>
-    <script src="app/blocks/config/localstorage.config.js"></script>
-    <script src="app/blocks/config/http.config.js"></script>
-    <script src="app/blocks/config/compile.config.js"></script>
-    <script src="app/blocks/config/alert.config.js"></script>
     <script src="app/admin/user-management/user-management.state.js"></script>
     <script src="app/admin/user-management/user-management.controller.js"></script>
     <script src="app/admin/user-management/user-management-dialog.controller.js"></script>
     <script src="app/admin/user-management/user-management-detail.controller.js"></script>
     <script src="app/admin/user-management/user-management-delete-dialog.controller.js"></script>
+    <script src="app/admin/health/health.state.js"></script>
+    <script src="app/admin/health/health.service.js"></script>
+    <script src="app/admin/health/health.modal.controller.js"></script>
+    <script src="app/admin/health/health.controller.js"></script>
     <script src="app/admin/tracker/tracker.state.js"></script>
     <script src="app/admin/tracker/tracker.service.js"></script>
     <script src="app/admin/tracker/tracker.controller.js"></script>
@@ -193,10 +198,6 @@
     <script src="app/admin/logs/logs.state.js"></script>
     <script src="app/admin/logs/logs.service.js"></script>
     <script src="app/admin/logs/logs.controller.js"></script>
-    <script src="app/admin/health/health.state.js"></script>
-    <script src="app/admin/health/health.service.js"></script>
-    <script src="app/admin/health/health.modal.controller.js"></script>
-    <script src="app/admin/health/health.controller.js"></script>
     <script src="app/admin/docs/docs.state.js"></script>
     <script src="app/admin/configuration/configuration.state.js"></script>
     <script src="app/admin/configuration/configuration.service.js"></script>
@@ -213,15 +214,18 @@
     <script src="app/account/password/password-strength-bar.directive.js"></script>
     <script src="app/account/activate/activate.state.js"></script>
     <script src="app/account/activate/activate.controller.js"></script>
+    <script src="app/timeline_backup/timeline.controller.js"></script>
     <script src="app/scripting/scriptingview.state.js"></script>
     <script src="app/scripting/scriptingview.controller.js"></script>
-    <script src="app/map/mapview.state.js"></script>
-    <script src="app/map/mapview.controller.js"></script>
-    <script src="app/entities/entity.state.js"></script>
+    <script src="app/map/map-table.directive.js"></script>
+    <script src="app/map/map-editor.state.js"></script>
+    <script src="app/map/map-editor.controller.js"></script>
+    <script src="app/map/fabric-map.directive.js"></script>
     <script src="app/home/loadproject-dialog.controller.js"></script>
     <script src="app/home/home.state.js"></script>
     <script src="app/home/home.controller.js"></script>
     <script src="app/home/createproject-dialog.controller.js"></script>
+    <script src="app/entities/entity.state.js"></script>
     <script src="app/admin/admin.state.js"></script>
     <script src="app/account/account.state.js"></script>
     <script src="app/app.state.js"></script>

--- a/src/test/javascript/karma.conf.js
+++ b/src/test/javascript/karma.conf.js
@@ -47,6 +47,7 @@ module.exports = function (config) {
             'src/main/webapp/bower_components/file-saver.js/FileSaver.js',
             'src/main/webapp/bower_components/angular-file-saver/dist/angular-file-saver.bundle.js',
             'src/main/webapp/bower_components/vis/dist/vis.min.js',
+            'src/main/webapp/bower_components/angular-animate/angular-animate.js',
             'src/main/webapp/bower_components/angular-mocks/angular-mocks.js',
             // endbower
             'src/main/webapp/app/app.module.js',


### PR DESCRIPTION
This is a fix for the map-editor state configuration. A typo was made. It now correctly points to `map-editor` instead of `mapeditor`. 
Also added index.html and karma.conf.js to include ngAnimate.